### PR TITLE
minikube configs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,10 +18,10 @@ jobs:
           password: ${{ secrets.CR_PAT }}
       - name: Save release image name
         run: |
-          echo ::set-env name=RELEASE_IMAGE::$(cat docker-compose.yaml | sed -n 's/^[ ]*image: \(ghcr.*$\)/\1/p')
+          echo "RELEASE_IMAGE=$(cat docker-compose.yaml | sed -n 's/^[ ]*image: \(ghcr.*$\)/\1/p')" >> $GITHUB_ENV
       - name: Save dev image name
         run: |
-          echo ::set-env name=DEV_IMAGE::$(cat docker-compose.yaml | sed -n 's/^[ ]*image: \(ghcr.*\):.*$/\1/p')
+          echo "DEV_IMAGE=$(cat docker-compose.yaml | sed -n 's/^[ ]*image: \(ghcr.*\):.*$/\1/p')" >> $GITHUB_ENV
       - name: Build Docker image
         run: docker-compose build
       - name: Push dev image to GitHub Container Registry

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 xnat-conf.properties
 .env
+ldap.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,10 @@ ENV LDAP_HOST= LDAP_USER= LDAP_PASSWORD= LDAP_SEARCH_BASE= LDAP_SEARCH_FILTER=
 ENV XNAT_SITE_URL= XNAT_ADMIN_EMAIL=
 ENV XNAT_SMTP_HOSTNAME= XNAT_SMTP_USER= XNAT_SMTP_PASSWORD= XNAT_SMTP_PORT= XNAT_SMTP_AUTH=true XNAT_SMTP_START_TLS=true
 
+# NOTE (BNR): Ports have the following use:
+#  8000 - Debug port, only used if debug is set to true
+#  8080 - Web port, this is how users connect to XNAT
+#  8104 - Scanner port, this is how the scanner connects to XNAT
 EXPOSE 8000/tcp 8080/tcp 8104/tcp
 
 ENTRYPOINT ["./bin/docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -7,16 +7,103 @@ XNAT does not provide a Docker image for XNAT itself (though they do
 provide a lot of Docker images that work with XNAT). The `Dockerfile`
 builds XNAT as it's used at Brown University.
 
-XNAT requires Apache Tomcat version 7, and JDK 1.8. No other versions are
-supported.
+XNAT requires Apache Tomcat version 7, JDK 1.8, and Postgresql 9. No other
+versions are supported.
+
+This repository provides two ways of running development versions of XNAT,
+via Docker Compose or Kubernetes.
+
+## Docker Compose
+
+To start the compose stack run:
+
+```
+$ docker-compose up
+```
+
+## Kubernetes
+
+First you must install minikube. See [this guide][1] for more details. I
+used `brew` on macOS to install minikube. Once minikube is installed, start
+it with the following command.
+
+Kubernetes version can be omitted, but I like to keep it there to make
+sure my manifests are compatible with my clusters. Make sure the driver
+you use matches your system configuration, and can support the nginx
+ingress controller.
+
+```
+$ minikube start --kubernetes-version=v1.18.10 --driver=hyperkit
+```
+
+Once minikube has started, enable the ingress controller if you haven't
+already.
+
+```
+$ minikube addons enable ingress
+```
+
+To run the Kubernetes deployment run:
+
+```
+$ kubectl apply -k .
+```
+
+This will set up XNAT with all the fixings including a local database.
+`app.yaml` contains the manifests related to XNAT, `db.yaml` contains the
+manifests for the database.
+
+By default XNAT is configured as a `ClusterIp` service, meaning that XNAT
+does not expose any external addresses. There are three ways to connect to
+XNAT: Kubernetes port-forwarding, curl, and `/etc/hosts`.
+
+Kubernetes offers a method of forwarding traffic to and from the cluster.
+With this we can proxy traffic to a service running inside the cluster.
+
+```
+$ kubectl port-forward svc/xnat 8080:80
+```
+
+This command will forward `localhost:8080` traffic to the XNAT service
+within the Kubernetes cluster. From there the service will forward the
+traffic to the deployment.
+
+If you want a quick sanity check, curl works great. The following command
+forces curl to resolve the address `xnat.local` to your minikube IP
+address. `xnat.local` is the name set up by the Kubernetes ingress, see
+`app.yaml` for more details.
+
+```
+$ curl -vL --resolve xnat.local:80:$(minikube ip) http://xnat.local
+```
+
+Lastly, if you're doing prolonged testing with XNAT you can update your
+hosts file to point `xnat.local` to your minikube IP address. This is
+basically what we did with the previous curl command, but permanent.
+
+```
+$ sudo sh -c "echo $(minikube ip) xnat.local >> /etc/hosts"
+```
+
+After updating your hosts file you should be able to use `xnat.local` to
+access your development XNAT deployment.
+
+## LDAP
+
+If you desire LDAP authentication, copy `ldap.env.example` to `ldap.env`
+and load your LDAP configuration. Then uncomment the `ldap-config` section
+in the `kustomization.yaml` file. Similarly, uncomment the `ldap-config`
+environment section in `app.yaml` and start the service as above.
 
 ## TODO
-* [ ] Trim down the `Dockerfile` to bare minimum necessary
-* [ ] Build and test the image using Docker
-* [ ] Create a repository, and deployer service account in the DTR
-* [ ] Create Kubernetes deployment manifest for XNAT
-* [ ] Deploy to minikube for test
-* [ ] Deploy to SciDMZ to for test
+* [x] Trim down the `Dockerfile` to bare minimum necessary
+* [x] Build and test the image using Docker
+* [x] Create a repository, and deployer service account in the DTR
+* [x] Create Kubernetes deployment manifest for XNAT
+* [x] Deploy to minikube for test
+* [x] Deploy to SciDMZ to for test
 * [ ] Configure TrueNAS storage mounts in the cluster
-* [ ] Configure Postgres storage for metadata
+* [x] Configure Postgres storage for metadata
 * [ ] Document the process
+
+[1]: https://minikube.sigs.k8s.io/docs/start/

--- a/app.yaml
+++ b/app.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: xnat
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: xnat
+  template:
+    metadata:
+      labels:
+        app: xnat
+    spec:
+      containers:
+      - name: xnat
+        image: ghcr.io/brown-bnc/xnat:1.7.6
+        envFrom:
+        - configMapRef:
+            name: app-config
+        - secretRef:
+            name: ldap-config
+        ports:
+        - name: http
+          containerPort: 8080
+        - name: dicom
+          containerPort: 8104
+        - name: debug
+          containerPort: 8000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: xnat
+  labels:
+    app: xnat
+spec:
+  type: ClusterIP
+  selector:
+    app: xnat
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8080
+      protocol: TCP
+    - name: dicom
+      port: 8104
+      targetPort: 8104
+      protocol: TCP
+---
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: xnat
+  labels:
+    app: xnat
+spec:
+  rules:
+    - host: xnat.local
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: xnat
+              servicePort: 80

--- a/db.yaml
+++ b/db.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:9
+          ports:
+            - containerPort: 5432
+          envFrom:
+            - configMapRef:
+                name: db-config
+          volumeMounts:
+            - mountPath: /var/lib/postgresql/data
+              name: db-data
+      volumes:
+        - name: db-data
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  labels:
+    app: postgres
+spec:
+  type: ClusterIP
+  selector:
+    app: postgres
+  ports:
+    - name: db
+      port: 5432
+      targetPort: 5432
+      protocol: TCP

--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -1,0 +1,23 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: xnat
+resources:
+- app.yaml
+- db.yaml
+configMapGenerator:
+- name: app-config
+  literals:
+  - CATALINA_OPTS=-Xms128m -Xmx1024m
+  - POSTGRES_HOST=postgres
+  - POSTGRES_PORT=5432
+  - POSTGRES_DB=xnat
+  - POSTGRES_USER=xnat
+  - POSTGRES_PASSWORD=xnat
+- name: db-config
+  literals:
+  - POSTGRES_DB=xnat
+  - POSTGRES_USER=xnat
+  - POSTGRES_PASSWORD=xnat
+secretGenerator:
+- name: ldap-config
+  env: ldap.env


### PR DESCRIPTION
This commit introduces minikube configuration for local development of XNAT. It includes a local database for testing, an ingress configuration and instructions for how to use the minikube version of XNAT.