### PR TITLE
Auto-enable LDAP provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,13 @@ and load your LDAP configuration. Then uncomment the `ldap-config` section
 in the `kustomization.yaml` file. Similarly, uncomment the `ldap-config`
 environment section in `app.yaml` and start the service as above.
 
+## Automatic Initialization
+
+If you want to skip the initialization page on first launch, provide both
+`$XNAT_SITE_URL` and `$XNAT_ADMIN_EMAIL` when starting XNAT. The default
+username/password will still be `admin:admin`. If you've provided an LDAP
+configuration, the automatic initialization will enable your LDAP provider.
+
 ## TODO
 * [x] Trim down the `Dockerfile` to bare minimum necessary
 * [x] Build and test the image using Docker

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -33,14 +33,13 @@ generate_auth_config() {
 name=LDAP
 provider.id=ldap
 auth.method=ldap
-visible=true
-auto.enabled=true
-auto.verified=true
 address=${LDAP_HOST}
 userdn=${LDAP_USER}
 password=${LDAP_PASSWORD}
 search.base=${LDAP_SEARCH_BASE}
 search.filter=${LDAP_SEARCH_FILTER}
+auto.enabled=true
+auto.verified=true
 EOF
 }
 
@@ -61,6 +60,10 @@ pipelinePath=/data/xnat/pipeline
 prearchivePath=/data/xnat/prearchive
 initialized=true
 EOF
+
+  if [ -n "${LDAP_HOST}" ]; then
+    echo "enabledProviders=[\"ldap\",\"localdb\"]" >> /data/xnat/home/config/prefs-init.ini
+  fi
 }
 
 generate_smtp_config() {

--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -13,6 +13,8 @@ configMapGenerator:
   - POSTGRES_DB=xnat
   - POSTGRES_USER=xnat
   - POSTGRES_PASSWORD=xnat
+  - XNAT_SITE_URL=http://xnat.local
+  - XNAT_ADMIN_EMAIL=admin@xnat.local
 - name: db-config
   literals:
   - POSTGRES_DB=xnat


### PR DESCRIPTION
This commit ensures that the LDAP provider is automatically enabled if the user specifies the minimal initial config (admin email and site url). Right now there's only support for a single LDAP provider. I'm going to add support for an arbitrary number of LDAP providers later.