### PR TITLE
update entrypoint to find auth property configs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,6 @@ RUN mkdir -p \
     /data/xnat/prearchive \
     /data/xnat/dicom-export
 
-COPY ldap-provider.properties.example /data/xnat/home/config/auth/ldap-provider.properties.example
 VOLUME ["/data/xnat/home/config", "/data/xnat/home/config/auth"]
 
 COPY --from=build "/root/xnat-web/build/libs/xnat-web-${XNAT_VERSION}.war" "${CATALINA_HOME}/webapps/ROOT.war"

--- a/README.md
+++ b/README.md
@@ -128,6 +128,10 @@ Examples are provided for both Kubernetes and Docker Swarm. Uncomment the
 LDAP sections in `app.yaml` and `kustomization.yaml` for Kubernetes.
 Uncomment the LDAP section in `docker-compose.yaml` for Docker Swarm.
 
+For an example of an LDAP provider configuration file, see `ldap-provider.properties.example`.
+
+For more details on setting up custom auth providers, see XNAT's documentation here: https://wiki.xnat.org/documentation/configuring-authentication-providers
+
 ## Automatic Initialization
 
 If you want to skip the initialization page on first launch, provide both

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -eo pipefail
-shopt -s extglob
+shopt -s nullglob 
 
 warn() {
   >&2 echo "$@"
@@ -35,7 +35,8 @@ generate_prefs_init() {
 
   local email_verification='true'
   local auth_providers='["localdb"]'
-  local auth_configs=($(find /data/xnat/home/config/auth/ -type f -name "*.properties"))
+  #local auth_configs=($(find /data/xnat/home/config/auth/ -type f -name "*.properties"))
+  local auth_configs=( /data/xnat/home/config/auth/*.properties )
   local provider_id=''
 
   if [ -z "${XNAT_SMTP_HOSTNAME}" ] || [ -z "${XNAT_SMTP_USER}" ] \

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -103,7 +103,6 @@ export_catalina_opts() {
 }
 
 main() {
-  echo "Entrypoint script is running..."
   generate_xnat_conf
   generate_prefs_init
   export_catalina_opts

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -35,7 +35,7 @@ generate_prefs_init() {
 
   local email_verification='true'
   local auth_providers='["localdb"]'
-  local auth_configs=($(find /data/xnat/home/config/auth/ -type f -not -name 'ldap-provider.properties.example'))
+  local auth_configs=($(find /data/xnat/home/config/auth/ -type f -name "*.properties"))
   local provider_id=''
 
   if [ -z "${XNAT_SMTP_HOSTNAME}" ] || [ -z "${XNAT_SMTP_USER}" ] \

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -35,7 +35,6 @@ generate_prefs_init() {
 
   local email_verification='true'
   local auth_providers='["localdb"]'
-  #local auth_configs=($(find /data/xnat/home/config/auth/ -type f -name "*.properties"))
   local auth_configs=( /data/xnat/home/config/auth/*.properties )
   local provider_id=''
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -35,7 +35,7 @@ generate_prefs_init() {
 
   local email_verification='true'
   local auth_providers='["localdb"]'
-  local auth_configs=(/data/xnat/home/config/auth/!(ldap-provider.properties.example))
+  local auth_configs=($(find /data/xnat/home/config/auth/ -type f -not -name 'ldap-provider.properties.example'))
   local provider_id=''
 
   if [ -z "${XNAT_SMTP_HOSTNAME}" ] || [ -z "${XNAT_SMTP_USER}" ] \
@@ -103,6 +103,7 @@ export_catalina_opts() {
 }
 
 main() {
+  echo "Entrypoint script is running..."
   generate_xnat_conf
   generate_prefs_init
   export_catalina_opts


### PR DESCRIPTION
## Update Docker Entrypoint to Find Authentication Configs

In the entrypoint script, the following line `local auth_configs=(/data/xnat/home/config/auth/!(ldap-provider.properties.example))` was yielding an error when no authentication property files were provided. 

Rather than an empty list, `auth_configs` was assigned the literal pattern string `/data/xnat/home/config/auth/!(ldap-provider.properties.example`.   Instead, we can use the find command to detect auth provider property files:  

`local auth_configs=($(find /data/xnat/home/config/auth/ -type f -not -name 'ldap-provider.properties.example'))`

This results in the correct behavior if a valid config file is present or absent.