### PR TITLE
set headless mode so javamelody can render charts plus add missing li…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 RUN apt-get update && apt-get install -y \
     curl \
-    unzip
+    unzip \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p \
     /data/xnat/archive \

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,8 @@ FROM tomcat:9-jdk8-openjdk-slim
 
 ENV XNAT_VERSION=1.9.1.1
 
+ENV CATALINA_OPTS="-Djava.awt.headless=true"
+
 RUN apt-get update && apt-get install -y \
     curl \
     unzip

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,13 @@ FROM tomcat:9-jdk8-openjdk-slim
 
 ENV XNAT_VERSION=1.9.1.1
 
-ENV CATALINA_OPTS="-Djava.awt.headless=true"
+ENV JAVA_TOOL_OPTIONS="-Djava.awt.headless=true"
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      libfreetype6 \
+      fontconfig \
+      fonts-dejavu-core \
+  && rm -rf /var/lib/apt/lists/*
 
 RUN apt-get update && apt-get install -y \
     curl \


### PR DESCRIPTION
## Fix Monitoring Page Graph Rendering

<img width="1229" height="623" alt="image" src="https://github.com/user-attachments/assets/b8fcf62d-b0de-4f6c-a3b1-2951f4d731d2" />

I think there were a couple things going wrong here.  First, libfreetype was not installed, so the font manager couldn't find it.  I found that the slim image of openjdk no longer ships with `fontconfig` and `libfreetype` (https://stackoverflow.com/questions/55454036/noclassdeffounderror-could-not-initialize-class-sun-awt-x11fontmanager).  

However, even after satisfying this dependency, I was still hitting the `Could not initialize class sun.awt.X11FontManager` exception.  After a little digging, I learned that Java AWT will default to using X11 pipeline for font management, which fails in containers without a display.  We need to set `ENV JAVA_TOOL_OPTIONS="-Djava.awt.headless=true"` to prevent this default from being triggered. 
```
19-Aug-2025 12:00:58.991 SEVERE [http-nio-8080-exec-1] 
        java.lang.UnsatisfiedLinkError: /usr/local/openjdk-8/jre/lib/amd64/libfontmanager.so: libfreetype.so.6: cannot open shared object file: No such file or directory
        
        
19-Aug-2025 12:00:58.995 SEVERE [http-nio-8080-exec-2] 
        java.lang.NoClassDefFoundError: Could not initialize class sun.awt.X11FontManager
```